### PR TITLE
pycrypto pip3 fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ### Usage
 ```bash
-$ viewstate -h
+$ viewgen -h
 usage: viewgen [-h] [--webconfig WEBCONFIG] [-m MODIFIER] [-c COMMAND]
                [--decode] [--guess] [--check] [--vkey VKEY] [--valg VALG]
                [--dkey DKEY] [--dalg DALG] [-e]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 colored
 viewstate
-pycrypto
+pycryptodome


### PR DESCRIPTION
For Python 3.7 `pycrypto` doesn't seem to work during installation. I changed it to `pycryptodome` to fix this, but I have not tested it with lower Python3 versions. Also fixed a minor typo in `README.md`